### PR TITLE
chore: update dependencies and CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,35 +1,36 @@
 #!/usr/bin/env node
 'use strict';
 
-var meow = require('meow');
-var gitviz = require('./'),
-	Watcher = require('./lib/watcher.js');
+const meow = require('meow');
+const gitviz = require('./');
+const Watcher = require('./lib/watcher.js');
 
-var cli = meow({
-	help: [
-		'Usage:',
-		'  gitviz [options] PATH',
-		'',
-		'Options:',
-		'  -w, --watch        watch the PATH for filechanges',
-		'  -h, --help         print usage information',
-		'  -v, --version      show version info and exit',
-		'',
-		'Examples:',
-		'  $ gitviz /path/to/git/project',
-	].join('\n')
-},{
-	alias: { h: 'help', v: 'version' , w: 'watch' },
-	boolean: ['watch']
+const helpText = `
+Usage
+  $ gitviz [options] PATH
+
+Options
+  -w, --watch  watch the PATH for filechanges
+
+Examples
+  $ gitviz /path/to/git/project
+`;
+
+const cli = meow(helpText, {
+  flags: {
+    watch: {
+      type: 'boolean',
+      alias: 'w'
+    }
+  }
 });
 
-var path = cli.input[0] || process.cwd();
+const path = cli.input[0] || process.cwd();
 
-if(cli.flags.watch) {
-	new Watcher(path).on('ping', function() {
-		gitviz(path);
-	});
+if (cli.flags.watch) {
+  new Watcher(path).on('ping', () => {
+    gitviz(path);
+  });
 }
 
 gitviz(path);
-

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   "repository": "chr1shaefn3r/gitviz.git",
   "license": "MIT",
   "dependencies": {
-    "debug": "^2.2.0",
-    "git-objectids": "^0.2.0",
-    "graphviz": "0.0.8",
-    "meow": "^3.7.0",
-    "nodegit": "^0.5.0",
-    "watch": "^0.19.1"
+    "debug": "^4.3.4",
+    "git-objectids": "^0.3.0",
+    "graphviz": "0.0.9",
+    "meow": "^9.0.0",
+    "nodegit": "^0.31.0",
+    "watch": "^1.0.2"
   },
   "keywords": [
     "gitviz",
@@ -40,6 +40,6 @@
     "generate-sample-gif": "bash scripts/generate_sample_gif.bash"
   },
   "devDependencies": {
-    "npm-check-updates": "^2.6.7"
+    "npm-check-updates": "^16.14.21"
   }
 }


### PR DESCRIPTION
## Summary
- bump runtime dependencies to newer releases
- modernize CLI to match current meow API
- update dev tooling version

## Testing
- `npm install` *(fails: nodegit install script throws TypeError)*
- `npm test` *(fails: Cannot find module 'meow')*

------
https://chatgpt.com/codex/tasks/task_e_68ac7e61c78c832994a9f319a841dcae